### PR TITLE
compatibility with Torchvision >= 0.9

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -33,7 +33,7 @@ def build_pred_transformations(params, convert_gray_to_rgb=False):
     if convert_gray_to_rgb:
         transform_list.append(transforms.Lambda(lambda img: img.convert('RGB')))
 
-    transform_list.append(transforms.RandomAffine(10, translate=(0.1, 0.1), scale=(0.9, 1.1), resample=Image.BICUBIC))
+    transform_list.append(transforms.RandomAffine(10, translate=(0.1, 0.1), scale=(0.9, 1.1), interpolation=transforms.InterpolationMode.BICUBIC))
     transform_list.append(transforms.Resize(params.img_shape))
 
     transform_list.append(transforms.ToTensor())


### PR DESCRIPTION
respample= was deprecated and ultimatelly removed after 0.9. This fix makes it compatibile with TV > 0.9. Tested with Torchvision 0.15.2.